### PR TITLE
fix: avoid telegram module shadowing

### DIFF
--- a/functions/main.py
+++ b/functions/main.py
@@ -7,7 +7,7 @@ from telegram import Update, Bot
 from agent import Agent
 from firestore_client import get_db
 from config import get_config, is_safe_mode
-from telegram import send_message_safe
+from telegram_utils import send_message_safe
 
 # Initialize Logger
 logging.basicConfig(level=logging.INFO)

--- a/functions/telegram_utils.py
+++ b/functions/telegram_utils.py
@@ -1,7 +1,5 @@
 import logging
-import asyncio
 from telegram import Bot
-from config import get_config
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Motivation
- The local helper module was named `telegram.py`, which shadowed the third-party `telegram` package and caused an `ImportError`/circular import during functions analysis.
- The fix prevents the runtime failure so the `python-telegram-bot` `Bot` class can be imported and used by the cloud function.

### Description
- Renamed the local helper module from `functions/telegram.py` to `functions/telegram_utils.py`.
- Updated the webhook import in `functions/main.py` from `from telegram import send_message_safe` to `from telegram_utils import send_message_safe`.
- Removed unused imports (`asyncio` and `config.get_config`) from the renamed `telegram_utils.py` to keep the helper minimal.
- Left usage of `from telegram import Update, Bot` in `functions/main.py` intact so the external package is used directly.

### Testing
- The Cloud Functions code analysis/deploy previously failed with an `ImportError` due to module shadowing.
- No automated tests were executed after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e817c10f0832f93e3a83f1c063303)