### PR TITLE
Use persistent event loop for Telegram sends to avoid 'Event loop is closed'

### DIFF
--- a/functions/main.py
+++ b/functions/main.py
@@ -1,7 +1,6 @@
 import os
 import json
 import logging
-import asyncio
 from firebase_functions import https_fn, scheduler_fn
 from telegram import Update, Bot
 from agent import Agent
@@ -20,7 +19,7 @@ agent = Agent()
 TELEGRAM_TOKEN = get_config("TELEGRAM_TOKEN")
 bot = Bot(token=TELEGRAM_TOKEN) if TELEGRAM_TOKEN else None
 
-async def handle_safe_mode(user_id: int, chat_id: int, text: str, bot: Bot):
+def handle_safe_mode(user_id: int, chat_id: int, text: str, bot: Bot):
     """
     Deterministic logic for Safe Mode (No LLM).
     """
@@ -32,27 +31,27 @@ async def handle_safe_mode(user_id: int, chat_id: int, text: str, bot: Bot):
     manifesto = get_manifesto(str(user_id))
     if manifesto == "No manifesto set.":
         set_manifesto(str(user_id), text)
-        await send_message_safe(bot, chat_id, f"[SAFE MODE] Manifesto set: {text}")
+        send_message_safe(bot, chat_id, f"[SAFE MODE] Manifesto set: {text}")
         return
 
     # 2. Commands
     if text_lower.startswith("add "):
         task = text[4:].strip()
         add_task(str(user_id), task)
-        await send_message_safe(bot, chat_id, f"[SAFE MODE] Task added: {task}")
+        send_message_safe(bot, chat_id, f"[SAFE MODE] Task added: {task}")
     elif text_lower == "list" or text_lower == "/list":
         tasks = get_pending_tasks(str(user_id))
         if not tasks:
-            await send_message_safe(bot, chat_id, "[SAFE MODE] No pending tasks.")
+            send_message_safe(bot, chat_id, "[SAFE MODE] No pending tasks.")
         else:
             msg = "\n".join([f"- {t['description']}" for t in tasks])
-            await send_message_safe(bot, chat_id, f"[SAFE MODE] Tasks:\n{msg}")
+            send_message_safe(bot, chat_id, f"[SAFE MODE] Tasks:\n{msg}")
     elif text_lower.startswith("done "):
         frag = text[5:].strip()
         res = complete_task(str(user_id), frag)
-        await send_message_safe(bot, chat_id, f"[SAFE MODE] {res}")
+        send_message_safe(bot, chat_id, f"[SAFE MODE] {res}")
     else:
-        await send_message_safe(bot, chat_id, f"[SAFE MODE] Unknown command. Available: add <task>, list, done <fragment>.")
+        send_message_safe(bot, chat_id, f"[SAFE MODE] Unknown command. Available: add <task>, list, done <fragment>.")
 
 @https_fn.on_request()
 def telegram_webhook(req: https_fn.Request) -> https_fn.Response:
@@ -89,7 +88,7 @@ def telegram_webhook(req: https_fn.Request) -> https_fn.Response:
         if update.message:
              # Handle new user /start
             if update.message.text == "/start":
-                 asyncio.run(send_message_safe(bot, update.message.chat_id, "Welcome! Tell me your Manifesto (Goal)."))
+                 send_message_safe(bot, update.message.chat_id, "Welcome! Tell me your Manifesto (Goal).")
                  return https_fn.Response("ok", status=200)
 
             if update.message.text:
@@ -99,17 +98,17 @@ def telegram_webhook(req: https_fn.Request) -> https_fn.Response:
 
                 # Check Safe Mode
                 if is_safe_mode():
-                    asyncio.run(handle_safe_mode(user_id, chat_id, text, bot))
+                    handle_safe_mode(user_id, chat_id, text, bot)
                     return https_fn.Response("ok", status=200)
 
                 # Process with Agent
                 try:
                     # TODO: Implement timeout logic if needed, but Cloud Functions has its own timeout.
                     response_text = agent.generate_response_with_tools(str(user_id), text)
-                    asyncio.run(send_message_safe(bot, chat_id, response_text))
+                    send_message_safe(bot, chat_id, response_text)
                 except Exception as e:
                     logger.error(f"Agent Error: {e}")
-                    asyncio.run(send_message_safe(bot, chat_id, "I encountered an internal error."))
+                    send_message_safe(bot, chat_id, "I encountered an internal error.")
 
             # Handle Captions (for photos/docs with text)
             elif update.message.caption:
@@ -154,7 +153,7 @@ def morning_briefing(event: scheduler_fn.ScheduledEvent) -> None:
             try:
                 message = agent.generate_morning_briefing(user_id)
                 if message:
-                    asyncio.run(send_message_safe(bot, int(user_id), message))
+                    send_message_safe(bot, int(user_id), message)
                     count += 1
             except Exception as e:
                 logger.error(f"Error generating briefing for {user_id}: {e}")

--- a/functions/telegram_utils.py
+++ b/functions/telegram_utils.py
@@ -1,13 +1,28 @@
+import asyncio
 import logging
+import threading
 from telegram import Bot
 
 logger = logging.getLogger(__name__)
 
-async def send_message_safe(bot: Bot, chat_id: int, text: str):
+_loop = asyncio.new_event_loop()
+_loop_lock = threading.Lock()
+
+
+def _run_in_loop(coro):
+    global _loop
+    with _loop_lock:
+        if _loop.is_closed():
+            _loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_loop)
+        return _loop.run_until_complete(coro)
+
+
+def send_message_safe(bot: Bot, chat_id: int, text: str):
     """
     Wrapper to send messages safely, logging errors instead of crashing.
     """
     try:
-        await bot.send_message(chat_id=chat_id, text=text)
+        _run_in_loop(bot.send_message(chat_id=chat_id, text=text))
     except Exception as e:
         logger.error(f"Failed to send message to {chat_id}: {e}")


### PR DESCRIPTION
### Motivation
- `asyncio.run()` was being invoked per request which can lead to `RuntimeError('Event loop is closed')` in serverless runtimes.
- The Telegram client (`python-telegram-bot` async) needs a stable event loop when called from synchronous webhook/scheduler handlers.

### Description
- Replaced the async `send_message_safe` with a synchronous wrapper in `functions/telegram_utils.py` that uses a module-level event loop `_loop`, a lock `_loop_lock`, and helper `_run_in_loop` to execute coroutines via `_loop.run_until_complete`.
- `send_message_safe` now calls `_run_in_loop(bot.send_message(...))` and continues to log send errors instead of raising.
- Updated `functions/main.py` to remove per-call `asyncio.run` usage, convert `handle_safe_mode` to a synchronous function, and call `send_message_safe` synchronously from webhook and scheduler code paths.
- Removed the now-unused `asyncio` import from `functions/main.py`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e92e768a8832fac7ec2578d8878b8)