### PR TITLE
Switch config to use OPENAI_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 TELEGRAM_TOKEN=your_token
-GEMINI_API_KEY=your_key
+OPENAI_API_KEY=your_key

--- a/functions/agent.py
+++ b/functions/agent.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class Agent:
     def __init__(self):
-        self.api_key = get_config("GEMINI_API_KEY")
+        self.api_key = get_config("OPENAI_API_KEY")
         self.client = None
         self.model = "gemini-3-flash-preview"
 
@@ -44,10 +44,10 @@ class Agent:
             return self.client
 
         if not self.api_key:
-            self.api_key = get_config("GEMINI_API_KEY")
+            self.api_key = get_config("OPENAI_API_KEY")
 
         if not self.api_key:
-            logger.warning("GEMINI_API_KEY not set. Agent will fail to generate responses.")
+            logger.warning("OPENAI_API_KEY not set. Agent will fail to generate responses.")
             return None
 
         try:

--- a/functions/config.py
+++ b/functions/config.py
@@ -19,8 +19,8 @@ def _parse_runtime_config(key: str) -> str:
         # key input: "TELEGRAM_TOKEN" -> we look for "telegram" -> "token"
         if key == "TELEGRAM_TOKEN":
             return config.get("telegram", {}).get("token")
-        elif key == "GEMINI_API_KEY":
-            return config.get("gemini", {}).get("key")
+        elif key == "OPENAI_API_KEY":
+            return config.get("openai", {}).get("key")
     except Exception as e:
         logger.warning(f"Failed to parse CLOUD_RUNTIME_CONFIG: {e}")
 


### PR DESCRIPTION
### Motivation
- Migrate secret handling from the legacy `GEMINI_API_KEY` name to `OPENAI_API_KEY` to align with how secrets are structured.
- Ensure the Agent reads the correct API key so LLM requests don't fail due to a mismatched environment variable.
- Update example environment documentation so new deployments use the updated key name.

### Description
- Update `_parse_runtime_config` in `functions/config.py` to map `OPENAI_API_KEY` to `config.get("openai", {}).get("key")` instead of the previous `gemini` lookup.
- Replace calls to `get_config("GEMINI_API_KEY")` with `get_config("OPENAI_API_KEY")` in `functions/agent.py` and update the corresponding warning message to reference `OPENAI_API_KEY`.
- Update `.env.example` to replace `GEMINI_API_KEY` with `OPENAI_API_KEY`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962cae92950832f8d60d52f8e0148b9)