### PR TITLE
Replace Gemini references with OpenAI (docs, requirements, tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # The Life OS (Firebase + MCP Edition)
 
-A proactive "Executive Coach" Telegram bot built on Firebase Cloud Functions and Google Gemini Pro using the MCP (Model Context Protocol) pattern for tools.
+A proactive "Executive Coach" Telegram bot built on Firebase Cloud Functions and OpenAI GPT-4o using the MCP (Model Context Protocol) pattern for tools.
 
 ## Architecture
 
 - **Backend**: Firebase Cloud Functions (2nd Gen) - Serverless Python.
 - **Database**: Google Cloud Firestore (NoSQL).
-- **Intelligence**: Google Gemini Pro (via `google-genai`).
+- **Intelligence**: OpenAI GPT-4o (via `openai`).
 - **Interface**: Telegram Bot API (Webhook).
 - **Tooling**: MCP-style tool definitions defined in `tools.py` and consumed by the Agent.
 
@@ -20,9 +20,9 @@ A proactive "Executive Coach" Telegram bot built on Firebase Cloud Functions and
 
 - Python 3.11+
 - Firebase CLI (`npm install -g firebase-tools`)
-- A Firebase Project (Blaze plan required for external network calls to Telegram/Gemini).
+- A Firebase Project (Blaze plan required for external network calls to Telegram/OpenAI).
 - Telegram Bot Token.
-- Gemini API Key.
+- OpenAI API Key.
 
 ## Setup
 
@@ -36,7 +36,7 @@ A proactive "Executive Coach" Telegram bot built on Firebase Cloud Functions and
     ```bash
     cp .env.example .env
     ```
-    Fill in `TELEGRAM_TOKEN` and `GEMINI_API_KEY`.
+    Fill in `TELEGRAM_TOKEN` and `OPENAI_API_KEY`.
 
 3.  **Firebase Init**:
     If you haven't already:

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1,7 +1,7 @@
 # The Life OS Telegram Bot — User Manual (v3.0)
 
 ## Upgrade Note (Version 3.0-flash)
-The Life OS has been upgraded to run on **Gemini 3.0 Flash**. This new engine supports advanced reasoning and faster responses.
+The Life OS has been upgraded to run on **OpenAI GPT-4o**. This new engine supports advanced reasoning and faster responses.
 
 ## What this app does
 The Life OS bot is a Telegram-based executive coach. It helps you:

--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -1,5 +1,5 @@
 firebase-admin
 firebase-functions
-google-genai
+openai
 python-telegram-bot
 python-dotenv

--- a/functions/test_endpoints.py
+++ b/functions/test_endpoints.py
@@ -8,7 +8,7 @@ import sys
 sys.modules['firebase_admin'] = MagicMock()
 sys.modules['firebase_admin.credentials'] = MagicMock()
 sys.modules['firebase_admin.firestore'] = MagicMock()
-sys.modules['google.generativeai'] = MagicMock()
+sys.modules['openai'] = MagicMock()
 
 # Mock the Agent class entirely
 mock_agent_instance = MagicMock()


### PR DESCRIPTION
### Motivation

- Remove references to Google Gemini and migrate to the OpenAI SDK and naming across the project.
- Ensure tests and dependency metadata reflect the new `openai` dependency so local/CI environments install the correct SDK.
- Keep test scaffolding mocking the LLM client so unit tests do not call the real API.
- Update user-facing docs to instruct users to provide `OPENAI_API_KEY` instead of the Gemini key.

### Description

- Replaced `google-genai` with `openai` in `functions/requirements.txt` to switch the declared SDK dependency.
- Adjusted `functions/test_endpoints.py` to mock the `openai` module instead of the Gemini module so tests import safely.
- Updated `README.md` to reference OpenAI GPT-4o and `OPENAI_API_KEY`, and changed wording about external network calls to OpenAI.
- Updated `USER_MANUAL.md` upgrade note to mention OpenAI GPT-4o in place of Gemini 3.0 Flash.

### Testing

- No automated test suite was executed as part of this change; edits were limited to docs and test scaffolding.
- The repository changes were committed locally and include the modified files `README.md`, `USER_MANUAL.md`, `functions/requirements.txt`, and `functions/test_endpoints.py`.
- Unit tests that exercise the real `Agent`/LLM behavior were not run and remain mocked by the adjusted test scaffolding.
- CI verification was not invoked in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962cc54eb30832f96a476bd04431b58)