### PR TITLE
Use OPENAI_API_KEY for Cloud Run secret binding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,4 +90,4 @@ jobs:
           gcloud run services update "${{ env.CLOUD_RUN_SERVICE }}" \
             --project "${{ env.FIREBASE_PROJECT_ID }}" \
             --region "${{ env.CLOUD_RUN_REGION }}" \
-            --update-secrets "TELEGRAM_TOKEN=TELEGRAM_TOKEN:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest"
+            --update-secrets "TELEGRAM_TOKEN=TELEGRAM_TOKEN:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest"


### PR DESCRIPTION
### Motivation
- Replace the previously-used `GEMINI_API_KEY` secret binding with `OPENAI_API_KEY` to match the current secret naming.
- Prevent Firebase Gen2 deploy from wiping out or re-binding the wrong secret for the Cloud Run service.
- Ensure Cloud Run receives the correct API key environment variable used by the application.
- Remind to verify that `OPENAI_API_KEY` exists in Google Secret Manager and in the repository secrets.

### Description
- Updated the deploy workflow file ` .github/workflows/deploy.yml` to change the Cloud Run secret binding.
- Replaced the `--update-secrets` entry from `GEMINI_API_KEY=GEMINI_API_KEY:latest` to `OPENAI_API_KEY=OPENAI_API_KEY:latest` alongside `TELEGRAM_TOKEN`.
- This change is limited to the Cloud Run secret rebinding step in the deploy job of the workflow.

### Testing
- No automated tests were run because this change only updates a CI workflow and does not modify application code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962cc91e888832f8efc2c19bc475f07)