### PR TITLE
Add `openai` to functions requirements (replace `google-genai`)

### DIFF
--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -1,5 +1,5 @@
 firebase-admin
 firebase-functions
-google-genai
+openai
 python-telegram-bot
 python-dotenv


### PR DESCRIPTION
### Motivation
- Deployment failed with `ModuleNotFoundError: No module named 'openai'` when importing `openai` in the functions code. 
- The functions requirements referenced the `google-genai` package which does not provide the `openai` module used by the code. 
- The intent is to ensure the runtime installs the correct OpenAI SDK so the functions can be analyzed and deployed. 

### Description
- Updated `functions/requirements.txt` to remove `google-genai` and add `openai`. 
- This makes the deployed environment install the OpenAI Python package expected by `agent.py`. 
- Change is limited to the dependency list and does not modify application logic. 

### Testing
- No automated tests were run after this change. 
- The change is dependency-only and intended to resolve the runtime import error observed during functions analysis.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c9050dbc832fb558f29c81ddd935)