### PR TITLE
Fix tool schema for Responses API compatibility

### DIFF
--- a/functions/agent.py
+++ b/functions/agent.py
@@ -122,14 +122,12 @@ class Agent:
         description = (tool.__doc__ or "").strip()
         return {
             "type": "function",
-            "function": {
-                "name": tool.__name__,
-                "description": description,
-                "parameters": {
-                    "type": "object",
-                    "properties": properties,
-                    "required": required,
-                },
+            "name": tool.__name__,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                "required": required,
             },
         }
 


### PR DESCRIPTION
### Motivation
- The OpenAI Responses API returned a runtime error: `Missing required parameter: 'tools[0].name'` when sending tool specs.
- The Responses API expects each tool to have top-level `name`, `description`, and `parameters` fields rather than a nested `function` object.
- The agent builds tool specifications via `_tool_to_schema`, so the schema shape needed to be adjusted to avoid API rejection.

### Description
- Changed `_tool_to_schema` in `functions/agent.py` to emit top-level `name`, `description`, and `parameters` keys instead of wrapping them under a `function` key.
- The returned schema still preserves inferred parameter types and `required` property calculation.
- This new shape is passed to `client.responses.create(..., tools=tool_specs)` so `tools` complies with Responses API expectations.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962d5eab3b0832f958d9a33b33bd96b)