### PR TITLE
Guard tool schema name generation

### DIFF
--- a/functions/agent.py
+++ b/functions/agent.py
@@ -120,9 +120,15 @@ class Agent:
             if param.default is inspect._empty:
                 required.append(name)
         description = (tool.__doc__ or "").strip()
+        tool_name = getattr(tool, "__name__", None) or getattr(tool, "__qualname__", None)
+        if not tool_name:
+            tool_name = f"tool_{id(tool)}"
+            logger.warning("Tool name missing; using fallback %s", tool_name)
+        elif not isinstance(tool_name, str):
+            tool_name = str(tool_name)
         return {
             "type": "function",
-            "name": tool.__name__,
+            "name": tool_name,
             "description": description,
             "parameters": {
                 "type": "object",


### PR DESCRIPTION
### Motivation
- The OpenAI Responses API can return a 400 error when a tool schema lacks a `name` (e.g. `Missing required parameter: 'tools[0].name'`).
- Ensure every tool schema always includes a stable `name` so `client.responses.create(..., tools=...)` does not fail.
- Make schema generation robust against tool objects that lack a normal `__name__` string.
- Add logging to aid debugging when a tool name fallback is used.

### Description
- Updated `_tool_to_schema` in `functions/agent.py` to compute `tool_name` via `getattr(tool, "__name__", None) or getattr(tool, "__qualname__", None)`.
- Added a fallback `tool_{id(tool)}` and a `logger.warning` when no name is present, and stringify non-string name values.
- Replaced the previous `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962d95760ac832f85b0dde138e9795c)