### PR TITLE
Switch agent default model to gpt-4o

### DIFF
--- a/functions/agent.py
+++ b/functions/agent.py
@@ -19,7 +19,7 @@ class Agent:
     def __init__(self):
         self.api_key = get_config("OPENAI_API_KEY")
         self.client = None
-        self.model = "gpt-4.1-mini"
+        self.model = "gpt-4o"
 
         self.system_instruction = (
             "You are a supportive, pragmatic friend-coach and expert guide for this Life OS app (Version 3.0). "


### PR DESCRIPTION
### Motivation
- Align the agent's default model with the repository docs and user manual that advertise GPT-4o.
- Use a more advanced model for improved reasoning and response quality.
- Maintain consistency between the bot configuration and the app's described capabilities.

### Description
- Updated the agent default model string in `functions/agent.py` by changing `self.model` from `"gpt-4.1-mini"` to `"gpt-4o"` inside `Agent.__init__`.
- The change is localized to the model selection and does not modify client initialization or tool handling logic.
- No other functional code paths were altered.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696310dd275c832f8800b0fee8fa4373)